### PR TITLE
prevent parse error on empty titles

### DIFF
--- a/packages/epub2/lib/epub.ts
+++ b/packages/epub2/lib/epub.ts
@@ -760,7 +760,7 @@ export class EPub extends EventEmitter
 						: (branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel || "").trim();
 					*/
 
-					title = (branch[i].navLabel && branch[i].navLabel.text || branch[i].navLabel || "").trim();
+					title = (branch[i].navLabel && branch[i].navLabel.text || "").trim();
 				}
 				var order = Number(branch[i]["@"] && branch[i]["@"].playOrder || 0);
 				if (isNaN(order))


### PR DESCRIPTION
Hey,

I noticed a parse error when the nav labels were empty string. The fallback that I removed was causing an object to be returned and the call to trim() was throwing an error. 

With this removed, worked perfectly fine for my use cases!

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>