### PR TITLE
removes # elements from href in walkNavMap

### DIFF
--- a/packages/epub2/lib/epub.js
+++ b/packages/epub2/lib/epub.js
@@ -552,7 +552,7 @@ class EPub extends events_1.EventEmitter {
                     title: title
                 };
                 if (href) {
-                    href = path.concat([href]).join("/");
+                    href = path.concat([href]).join("/").split("#").shift();
                     element.href = href;
                     if (id_list[element.href]) {
                         // link existing object

--- a/packages/epub2/lib/epub.ts
+++ b/packages/epub2/lib/epub.ts
@@ -783,7 +783,7 @@ export class EPub extends EventEmitter
 
 				if (href)
 				{
-					href = path.concat([href]).join("/");
+					href = path.concat([href]).join("/").split("#").shift();
 					element.href = href;
 
 					if (id_list[element.href])


### PR DESCRIPTION
I was having an issue where an epub I was working with had a hashtag in the href. It was causing an issue where an item that actually exists in the id_list wasn't getting recognized because the id_list didn't have the hashtag in it. This addresses this issue.

The root issue seems to exist a bit deeper in the xml parser, but I wasn't able to identify where—so this quick fix addressed it.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>