### PR TITLE
fix(linkparts): type error when empty link

### DIFF
--- a/packages/epub2/lib/epub.ts
+++ b/packages/epub2/lib/epub.ts
@@ -958,7 +958,7 @@ export class EPub extends EventEmitter
 			// replace links
 			str = str.replace(/(\shref\s*=\s*["']?)([^"'\s>]*?)(["'\s>])/g, (o, a, b, c) =>
 			{
-				var linkparts = b && b.split("#"),
+				var linkparts = b && b.split("#") || [],
 					link = path.concat([(linkparts.shift() || "")]).join("/").trim(),
 					element;
 


### PR DESCRIPTION
Fixes `TypeError: linkparts.shift is not a function` error